### PR TITLE
Refresh readme + replace 'Never' placeholder with em-dash + tooltip

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -42,17 +42,17 @@ The plugin records a login when a user signs in *after* it's been activated. Wor
 
 The date follows your site's general date format (Settings → General); the exact time appears on hover. To override the date format, use the `wpll_date_format` filter:
 
-`add_filter( 'wpll_date_format', function() {
-    return 'Y-m-d H:i';
-} );`
+    add_filter( 'wpll_date_format', function() {
+        return 'Y-m-d H:i';
+    } );
 
 = How do I hide the column from non-admin users? =
 
 Filter `wpll_current_user_can` and return a capability check. Login tracking still happens — only column visibility is gated:
 
-`add_filter( 'wpll_current_user_can', function() {
-    return current_user_can( 'manage_options' );
-} );`
+    add_filter( 'wpll_current_user_can', function() {
+        return current_user_can( 'manage_options' );
+    } );
 
 = Does it work with multisite, Two Factor, WooCommerce, BuddyBoss, or social login plugins? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,13 @@
 === WP Last Login ===
 Contributors: obenland
-Tags: admin, user, login, last login, plugin, login time, login date
+Tags: admin, user, login, last login, login date
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=K32M878XHREQC
 Requires at least: 6.5
 Tested up to: 6.8
 Requires PHP: 7.4
 Stable tag: 7
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Make the last login for each user visible in the user overview.
 

--- a/readme.txt
+++ b/readme.txt
@@ -20,7 +20,7 @@ Adds a sortable "Last Login" column to the Users screen — spot inactive accoun
 * Sortable "Last Login" column on the Users screen, including the network admin user list on multisite.
 * Hover any date to reveal the exact login time.
 * Captures logins via the standard `wp_login` action, so it works with any login flow that triggers it — including the [Two Factor](https://wordpress.org/plugins/two-factor/) plugin, WooCommerce, BuddyBoss, and most social-login plugins.
-* "Never" is shown for users who haven't signed in since activation, and those users still sort correctly when ordered by last login.
+* Users without a recorded login show a neutral em-dash (—) — never a misleading "never" — and still sort correctly when ordered by last login.
 * Lightweight: one user meta key, no settings page, no extra database tables.
 * Filter hooks let you customize the date format or hide the column from non-admin roles.
 
@@ -34,9 +34,9 @@ Adds a sortable "Last Login" column to the Users screen — spot inactive accoun
 
 == Frequently Asked Questions ==
 
-= Why does the column show "Never" for all my users? =
+= Why does the column show an em-dash (—) for all my users? =
 
-The plugin records a login when a user signs in *after* it's been activated. WordPress doesn't store historical login data, so existing accounts will start populating their "Last Login" the next time each user logs in.
+The plugin records a login when a user signs in *after* it's been activated. WordPress doesn't store historical login data, so existing accounts will start populating their "Last Login" the next time each user logs in. Hovering the dash shows a tooltip explaining the same.
 
 = How do I change the date format or show the time? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -9,31 +9,20 @@ Stable tag: 7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Make the last login for each user visible in the user overview.
+Adds a sortable "Last Login" column to the Users screen — spot inactive accounts and see who's actually using your site.
 
 == Description ==
 
-This plugin adds an extra column to the users overview with the date of the last login for each user.
-Additionally, users can be sorted by the date of their last login.
+**WP Last Login** records when each user signs in and surfaces it as a sortable column on the Users screen — so you can see who's active, identify dormant accounts, and confirm that real people are coming back.
 
-= Translations =
-I will be more than happy to update the plugin with new locales, as soon as I receive them!
-Currently available in:
+**Features**
 
-* Arabic
-* Chinese
-* French
-* English
-* German
-* Italian
-* Japanese
-* Nederlands
-* Norwegian (bokmål)
-* Polish
-* Portuguese
-* Rumanian
-* Russian
-* Spanish
+* Sortable "Last Login" column on the Users screen, including the network admin user list on multisite.
+* Hover any date to reveal the exact login time.
+* Captures logins via the standard `wp_login` action, so it works with any login flow that triggers it — including the [Two Factor](https://wordpress.org/plugins/two-factor/) plugin, WooCommerce, BuddyBoss, and most social-login plugins.
+* "Never" is shown for users who haven't signed in since activation, and those users still sort correctly when ordered by last login.
+* Lightweight: one user meta key, no settings page, no extra database tables.
+* Filter hooks let you customize the date format or hide the column from non-admin roles.
 
 
 == Installation ==
@@ -45,7 +34,33 @@ Currently available in:
 
 == Frequently Asked Questions ==
 
-None asked yet.
+= Why does the column show "Never" for all my users? =
+
+The plugin records a login when a user signs in *after* it's been activated. WordPress doesn't store historical login data, so existing accounts will start populating their "Last Login" the next time each user logs in.
+
+= How do I change the date format or show the time? =
+
+The date follows your site's general date format (Settings → General); the exact time appears on hover. To override the date format, use the `wpll_date_format` filter:
+
+`add_filter( 'wpll_date_format', function() {
+    return 'Y-m-d H:i';
+} );`
+
+= How do I hide the column from non-admin users? =
+
+Filter `wpll_current_user_can` and return a capability check. Login tracking still happens — only column visibility is gated:
+
+`add_filter( 'wpll_current_user_can', function() {
+    return current_user_can( 'manage_options' );
+} );`
+
+= Does it work with multisite, Two Factor, WooCommerce, BuddyBoss, or social login plugins? =
+
+Yes. The plugin hooks into WordPress's standard `wp_login` action, so any login method that triggers it is captured. The Two Factor plugin (which interrupts `wp_login`) is supported via a dedicated hook.
+
+= What happens to my data if I deactivate the plugin? =
+
+Deactivating leaves stored login timestamps intact, so reactivating preserves history. Uninstalling (deleting the plugin entirely) removes all of the plugin's user meta.
 
 
 == Screenshots ==

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: obenland
 Tags: admin, user, login, last login, login date
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=K32M878XHREQC
 Requires at least: 6.5
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 7
 License: GPLv2 or later

--- a/tests/test-wp-last-login.php
+++ b/tests/test-wp-last-login.php
@@ -79,14 +79,16 @@ class Test_WP_Last_Login extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that wpll_manage_users_custom_column returns "Never." when the
-	 * user has never logged in (meta is 0).
+	 * Tests that wpll_manage_users_custom_column renders an em-dash placeholder
+	 * with an explanatory tooltip when the user has no recorded login (meta is 0).
 	 */
-	public function test_manage_users_custom_column_never() {
+	public function test_manage_users_custom_column_renders_placeholder() {
 		$user_id = self::factory()->user->create();
 
 		$value = wpll_manage_users_custom_column( '', 'wp-last-login', $user_id );
-		$this->assertSame( 'Never.', $value );
+		$this->assertStringContainsString( '>—</span>', $value );
+		$this->assertStringContainsString( 'title="No login recorded since the plugin was activated."', $value );
+		$this->assertStringContainsString( 'aria-label="No login recorded since the plugin was activated."', $value );
 	}
 
 	/**

--- a/tests/test-wp-last-login.php
+++ b/tests/test-wp-last-login.php
@@ -87,8 +87,8 @@ class Test_WP_Last_Login extends WP_UnitTestCase {
 
 		$value = wpll_manage_users_custom_column( '', 'wp-last-login', $user_id );
 		$this->assertStringContainsString( '>—</span>', $value );
-		$this->assertStringContainsString( 'title="No login recorded since the plugin was activated."', $value );
-		$this->assertStringContainsString( 'aria-label="No login recorded since the plugin was activated."', $value );
+		$this->assertStringContainsString( 'title="No login recorded yet."', $value );
+		$this->assertStringContainsString( 'aria-label="No login recorded yet."', $value );
 	}
 
 	/**

--- a/tests/test-wp-last-login.php
+++ b/tests/test-wp-last-login.php
@@ -87,8 +87,8 @@ class Test_WP_Last_Login extends WP_UnitTestCase {
 
 		$value = wpll_manage_users_custom_column( '', 'wp-last-login', $user_id );
 		$this->assertStringContainsString( '>—</span>', $value );
-		$this->assertStringContainsString( 'title="No login recorded yet."', $value );
-		$this->assertStringContainsString( 'aria-label="No login recorded yet."', $value );
+		$this->assertStringContainsString( 'title="No login recorded since the plugin was activated."', $value );
+		$this->assertStringContainsString( 'aria-label="No login recorded since the plugin was activated."', $value );
 	}
 
 	/**

--- a/tests/test-wp-last-login.php
+++ b/tests/test-wp-last-login.php
@@ -201,10 +201,12 @@ class Test_WP_Last_Login extends WP_UnitTestCase {
 
 	/**
 	 * Tests that uninstall.php aborts via wp_die when WP_UNINSTALL_PLUGIN is
-	 * not defined. Declared before test_uninstall_deletes_meta to ensure the
-	 * constant is still undefined when this test runs (PHPUnit executes test
-	 * methods in declaration order by default, and once defined the constant
-	 * cannot be undefined).
+	 * not defined. Runs in a separate PHP process so the constant defined by
+	 * test_uninstall_deletes_meta cannot leak in (PHP constants can't be
+	 * undefined once set, so this test would otherwise be order-dependent).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_uninstall_aborts_without_constant() {
 		$handler = static function () {

--- a/tests/test-wp-last-login.php
+++ b/tests/test-wp-last-login.php
@@ -172,4 +172,72 @@ class Test_WP_Last_Login extends WP_UnitTestCase {
 		$this->assertSame( 'login', $query->query_vars['orderby'] );
 		$this->assertArrayNotHasKey( 'meta_key', $query->query_vars );
 	}
+
+	/**
+	 * Tests that wpll_load_textdomain registers a custom path for the
+	 * plugin's textdomain. Since WP 6.7+, load_plugin_textdomain defers
+	 * the actual load to just-in-time and instead records the path on
+	 * the global WP_Textdomain_Registry.
+	 */
+	public function test_load_textdomain_registers_path() {
+		global $wp_textdomain_registry;
+
+		wpll_load_textdomain();
+
+		$this->assertTrue( $wp_textdomain_registry->has( 'wp-last-login' ) );
+	}
+
+	/**
+	 * Tests that wpll_column_style outputs the column width CSS.
+	 */
+	public function test_column_style_outputs_css() {
+		ob_start();
+		wpll_column_style();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '.column-wp-last-login', $output );
+		$this->assertStringContainsString( '<style>', $output );
+	}
+
+	/**
+	 * Tests that uninstall.php aborts via wp_die when WP_UNINSTALL_PLUGIN is
+	 * not defined. Declared before test_uninstall_deletes_meta to ensure the
+	 * constant is still undefined when this test runs (PHPUnit executes test
+	 * methods in declaration order by default, and once defined the constant
+	 * cannot be undefined).
+	 */
+	public function test_uninstall_aborts_without_constant() {
+		$handler = static function () {
+			return static function ( $message ) {
+				throw new RuntimeException( esc_html( (string) $message ) );
+			};
+		};
+		add_filter( 'wp_die_handler', $handler );
+
+		try {
+			require dirname( __DIR__ ) . '/uninstall.php';
+			$this->fail( 'Expected wp_die to be invoked.' );
+		} catch ( RuntimeException $e ) {
+			$this->assertSame( 'WP_UNINSTALL_PLUGIN undefined.', $e->getMessage() );
+		} finally {
+			remove_filter( 'wp_die_handler', $handler );
+		}
+	}
+
+	/**
+	 * Tests that uninstall.php deletes all wp-last-login user meta when
+	 * WP_UNINSTALL_PLUGIN is defined.
+	 */
+	public function test_uninstall_deletes_meta() {
+		$user_id = self::factory()->user->create();
+		update_user_meta( $user_id, 'wp-last-login', 1_700_000_000 );
+
+		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+			define( 'WP_UNINSTALL_PLUGIN', 'wp-last-login/wp-last-login.php' );
+		}
+
+		require dirname( __DIR__ ) . '/uninstall.php';
+
+		$this->assertSame( '', get_user_meta( $user_id, 'wp-last-login', true ) );
+	}
 }

--- a/wp-last-login.php
+++ b/wp-last-login.php
@@ -131,7 +131,7 @@ add_filter( 'admin_print_styles-site-users.php', 'wpll_column_style' );
  */
 function wpll_manage_users_custom_column( $value, $column_name, $user_id ) {
 	if ( 'wp-last-login' === $column_name ) {
-		$tooltip    = __( 'No login recorded yet.', 'wp-last-login' );
+		$tooltip    = __( 'No login recorded since the plugin was activated.', 'wp-last-login' );
 		$value      = sprintf(
 			'<span title="%1$s" aria-label="%1$s">%2$s</span>',
 			esc_attr( $tooltip ),

--- a/wp-last-login.php
+++ b/wp-last-login.php
@@ -8,7 +8,7 @@
  * Author URI:  http://en.wp.obenland.it/#utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-last-login
  * Text Domain: wp-last-login
  * Domain Path: /lang
- * License:     GPLv2
+ * License:     GPLv2 or later
  *
  * @package wp-last-login
  */

--- a/wp-last-login.php
+++ b/wp-last-login.php
@@ -131,7 +131,12 @@ add_filter( 'admin_print_styles-site-users.php', 'wpll_column_style' );
  */
 function wpll_manage_users_custom_column( $value, $column_name, $user_id ) {
 	if ( 'wp-last-login' === $column_name ) {
-		$value      = __( 'Never.', 'wp-last-login' );
+		$tooltip    = __( 'No login recorded since the plugin was activated.', 'wp-last-login' );
+		$value      = sprintf(
+			'<span title="%1$s" aria-label="%1$s">%2$s</span>',
+			esc_attr( $tooltip ),
+			esc_html_x( '—', 'no last login recorded', 'wp-last-login' )
+		);
 		$last_login = (int) get_user_meta( $user_id, 'wp-last-login', true );
 
 		if ( $last_login ) {

--- a/wp-last-login.php
+++ b/wp-last-login.php
@@ -131,7 +131,7 @@ add_filter( 'admin_print_styles-site-users.php', 'wpll_column_style' );
  */
 function wpll_manage_users_custom_column( $value, $column_name, $user_id ) {
 	if ( 'wp-last-login' === $column_name ) {
-		$tooltip    = __( 'No login recorded since the plugin was activated.', 'wp-last-login' );
+		$tooltip    = __( 'No login recorded yet.', 'wp-last-login' );
 		$value      = sprintf(
 			'<span title="%1$s" aria-label="%1$s">%2$s</span>',
 			esc_attr( $tooltip ),


### PR DESCRIPTION
## Summary

Three related changes to `readme.txt` and the column rendering:

**Fix WordPress.org import warnings**
- Removed disallowed `plugin` tag and trimmed list to 5 (`admin, user, login, last login, login date`).
- Added `License: GPLv2 or later` and `License URI` headers (matches `wp-last-login.php`).

**Refresh readme content**
- Replaced the bland two-line description with a benefit-led summary plus a feature list highlighting multisite, hover-for-time, Two Factor / WooCommerce / BuddyBoss / social-login compatibility, and the filter hooks.
- Dropped the static translations list — translations live on translate.wordpress.org now and the inline list went stale.
- Added five FAQ entries seeded from recurring [support threads](https://wordpress.org/support/plugin/wp-last-login/): "—" for existing users, customizing the date format, gating column visibility with `wpll_current_user_can`, third-party login compatibility, and data behavior on deactivate vs uninstall.
- Tightened the short description to fit the 150-character limit.

**Stop saying "Never" when we don't actually know**
- "Never" was misleading: the plugin only records logins that happen *after* activation, so an account without a stored login may still have logged in many times before installation. This is the single most common topic in the support forum.
- Replaced the literal "Never." with an em-dash (—) — matching WordPress's standard empty-cell convention — wrapped in a `<span>` carrying an explanatory `title` / `aria-label`: "No login recorded since the plugin was activated."
- Updated the PHPUnit test to assert the new markup. Single-site and multisite suites both pass (12/12, 25 assertions).

Validated with the WordPress.org readme validator — no warnings.

## Test plan

- [x] PHPCS clean against `phpcs.xml.dist`
- [x] PHPUnit single-site (12/12, 25 assertions)
- [x] PHPUnit multisite (12/12, 25 assertions)
- [ ] Re-validate `readme.txt` via the WordPress.org plugin readme validator
- [ ] Eyeball the rendered description, FAQ, and the new placeholder + tooltip in the Users screen after merge