### PR TITLE
Validate against latest WordPress before bumping Tested up to

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -14,7 +14,44 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    validate:
+        name: Validate against latest WordPress
+        if: github.ref == 'refs/heads/trunk'
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        env:
+            WP_ENV_CORE: 'https://wordpress.org/wordpress-latest.zip'
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Setup Node.js (.nvmrc)
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: npm
+
+            - name: Cache Composer dependencies
+              uses: actions/cache@v5
+              id: composer-cache
+              with:
+                  path: vendor
+                  key: composer-${{ hashFiles('composer.json') }}
+
+            - name: Install PHP dependencies
+              if: steps.composer-cache.outputs.cache-hit != 'true'
+              run: composer update --prefer-dist --no-progress
+
+            - name: npm install
+              run: npm ci
+
+            - name: Start WordPress (latest stable)
+              run: npm run wp-env start
+
+            - name: Run PHP unit tests against latest WordPress
+              run: npm run test-php
+
     update:
+        needs: validate
         if: github.ref == 'refs/heads/trunk'
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
     validate:
         name: Validate against latest WordPress
+        permissions:
+            contents: read
         if: github.ref == 'refs/heads/trunk'
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -35,11 +37,11 @@ jobs:
               id: composer-cache
               with:
                   path: vendor
-                  key: composer-${{ hashFiles('composer.json') }}
+                  key: composer-${{ hashFiles('composer.lock') }}
 
             - name: Install PHP dependencies
               if: steps.composer-cache.outputs.cache-hit != 'true'
-              run: composer update --prefer-dist --no-progress
+              run: composer install --prefer-dist --no-progress
 
             - name: npm install
               run: npm ci


### PR DESCRIPTION
Adds a `validate` job to `update-tested-up-to.yml` that runs the plugins existing tests against the latest stable WordPress before bumping `Tested up to:`. The cron `update` job now `needs: validate`, so a test failure aborts the workflow and the readme bump never happens.

The validate job sets `WP_ENV_CORE: 'https://wordpress.org/wordpress-latest.zip'` so `wp-env start` resolves to the latest stable WordPress, then runs the same test commands the existing PR-triggered CI uses.

This means a Monday cron run on this repo now means: *we actually tested the plugin against the new WordPress before claiming compatibility*, not just blind-bumping the metadata.