### PR TITLE
Pin composer dependencies to lockfile in PHPUnit workflows

### DIFF
--- a/.github/workflows/phpunit-coverage.yml
+++ b/.github/workflows/phpunit-coverage.yml
@@ -39,11 +39,11 @@ jobs:
               id: composer-cache
               with:
                   path: vendor
-                  key: composer-coverage-${{ hashFiles('composer.json') }}
+                  key: composer-coverage-${{ hashFiles('composer.lock') }}
 
             - name: Install PHP dependencies
               if: steps.composer-cache.outputs.cache-hit != 'true'
-              run: composer update --prefer-dist --no-progress
+              run: composer install --prefer-dist --no-progress
 
             - name: npm install
               run: npm ci

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -58,11 +58,11 @@ jobs:
               id: composer-cache
               with:
                   path: vendor
-                  key: composer-php${{ matrix.php }}-${{ hashFiles('composer.json') }}
+                  key: composer-php${{ matrix.php }}-${{ hashFiles('composer.lock') }}
 
             - name: Install PHP dependencies
               if: steps.composer-cache.outputs.cache-hit != 'true'
-              run: composer update --prefer-dist --no-progress
+              run: composer install --prefer-dist --no-progress
 
             - name: npm install
               run: npm ci


### PR DESCRIPTION
## Summary

- Both PHPUnit workflows were running `composer update`, ignoring the lockfile and walking transitive deps to their newest matching versions every run.
- Once dependabot bumps yoast/phpunit-polyfills to ^4.0 (PR #24), this will pull phpunit ≥12 — which requires PHP 8.3+. The matrix includes PHP 7.4, so the install step will break.
- Switch both workflows to `composer install` with the cache key based on `composer.lock`. That keeps phpunit pinned at the lockfile-recorded 9.x, which the WP test scaffold supports.
- Same fix already applied to wp-approve-user#83. Aligns wp-last-login with how change-from-address and wp-search-suggest already do it.

## Test plan

- [ ] PHPUnit job passes on PHP 7.4 / WP 6.5
- [ ] PHPUnit job passes on PHP 8.3 / WP latest
- [ ] PHPUnit job passes on PHP 8.5 / WP trunk
- [ ] Coverage workflow still runs cleanly