### PR TITLE
Grant pull-requests: write to PHPUnit coverage workflow

### DIFF
--- a/.github/workflows/phpunit-coverage.yml
+++ b/.github/workflows/phpunit-coverage.yml
@@ -16,6 +16,15 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+    # The post-coverage step (`peter-evans/create-or-update-comment`) needs to
+    # write the coverage summary back to the PR. Dependabot PRs run with a
+    # read-only token by default, so without this the comment step fails
+    # with "Resource not accessible by integration" and turns the whole
+    # coverage check red.
+    pull-requests: write
+
 jobs:
     php-coverage:
         name: 'PHP Coverage Analysis'


### PR DESCRIPTION
## Summary

The PHPUnit coverage workflow runs `peter-evans/create-or-update-comment` to post the coverage summary back to the PR. Dependabot PRs run with a read-only `GITHUB_TOKEN`, so the comment step fails with:

> `Resource not accessible by integration`

…and turns the whole coverage check red, even though the actual coverage analysis ran fine. Last seen on #25.

Add an explicit top-level `permissions:` block:

- `contents: read` (default, kept for clarity)
- `pull-requests: write` so the coverage comment can be posted

Mirrors what `block-for-strava` already does in its coverage workflows.

## Test plan

- [ ] PHP Coverage Analysis check goes green on the next Dependabot PR
- [ ] Coverage comment lands on that PR