### PR TITLE
Bump vulnerable transitive deps via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2457,6 +2457,24 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2503,6 +2521,14 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@eslint/js": {
 			"version": "9.39.4",
@@ -8994,6 +9020,23 @@
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
+		"node_modules/@wordpress/scripts/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/@wordpress/scripts/node_modules/balanced-match": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -9150,6 +9193,13 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/@wordpress/scripts/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@wordpress/scripts/node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -9302,6 +9352,23 @@
 				"npm": ">=10.2.3"
 			}
 		},
+		"node_modules/@wp-playground/blueprints/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/@wp-playground/blueprints/node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9359,6 +9426,23 @@
 			},
 			"bin": {
 				"wp-playground-cli": "wp-playground.js"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/@wp-playground/cli/node_modules/ignore": {
@@ -9474,6 +9558,23 @@
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/@wp-playground/tools/node_modules/ignore": {
@@ -13638,6 +13739,24 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
+		"node_modules/eslint/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "8.4.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -13698,6 +13817,14 @@
 			"engines": {
 				"node": ">= 4"
 			}
+		},
+		"node_modules/eslint/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/eslint/node_modules/locate-path": {
 			"version": "6.0.0",
@@ -19125,6 +19252,23 @@
 				"npm": ">=6.0.0"
 			}
 		},
+		"node_modules/npm-package-json-lint/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/npm-package-json-lint/node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -19165,6 +19309,13 @@
 			"engines": {
 				"node": ">= 4"
 			}
+		},
+		"node_modules/npm-package-json-lint/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/npm-package-json-lint/node_modules/semver": {
 			"version": "7.8.0",
@@ -25067,6 +25218,16 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"node_modules/url-loader": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
@@ -25095,6 +25256,23 @@
 				}
 			}
 		},
+		"node_modules/url-loader/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/url-loader/node_modules/ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -25104,6 +25282,13 @@
 			"peerDependencies": {
 				"ajv": "^6.9.1"
 			}
+		},
+		"node_modules/url-loader/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/url-loader/node_modules/schema-utils": {
 			"version": "3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,9 +1225,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-			"integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+			"version": "7.29.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+			"integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2457,24 +2457,6 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/ajv": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2521,14 +2503,6 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
-		},
-		"node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@eslint/js": {
 			"version": "9.39.4",
@@ -9020,23 +8994,6 @@
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/ajv": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/balanced-match": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -9192,13 +9149,6 @@
 			"engines": {
 				"node": ">= 4"
 			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@wordpress/scripts/node_modules/locate-path": {
 			"version": "6.0.0",
@@ -9704,16 +9654,16 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -10227,13 +10177,13 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+			"integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.11",
+				"follow-redirects": "^1.16.0",
 				"form-data": "^4.0.5",
 				"proxy-from-env": "^2.1.0"
 			}
@@ -10556,9 +10506,9 @@
 			}
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-			"integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13688,24 +13638,6 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
-		"node_modules/eslint/node_modules/ajv": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "8.4.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -13766,14 +13698,6 @@
 			"engines": {
 				"node": ">= 4"
 			}
-		},
-		"node_modules/eslint/node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/eslint/node_modules/locate-path": {
 			"version": "6.0.0",
@@ -14189,10 +14113,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -14202,7 +14143,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
 			}
 		},
 		"node_modules/fast-xml-parser": {
@@ -15831,9 +15773,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -19183,23 +19125,6 @@
 				"npm": ">=6.0.0"
 			}
 		},
-		"node_modules/npm-package-json-lint/node_modules/ajv": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/npm-package-json-lint/node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -19240,13 +19165,6 @@
 			"engines": {
 				"node": ">= 4"
 			}
-		},
-		"node_modules/npm-package-json-lint/node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/npm-package-json-lint/node_modules/semver": {
 			"version": "7.8.0",
@@ -25149,16 +25067,6 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"node_modules/uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"punycode": "^2.1.0"
-			}
-		},
 		"node_modules/url-loader": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
@@ -25187,23 +25095,6 @@
 				}
 			}
 		},
-		"node_modules/url-loader/node_modules/ajv": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/url-loader/node_modules/ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -25213,13 +25104,6 @@
 			"peerDependencies": {
 				"ajv": "^6.9.1"
 			}
-		},
-		"node_modules/url-loader/node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/url-loader/node_modules/schema-utils": {
 			"version": "3.3.0",
@@ -26308,6 +26192,22 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 		"@babel/plugin-transform-modules-systemjs": "^7.29.4",
 		"fast-xml-builder": "^1.1.7",
 		"ip-address": "^10.1.1",
-		"ajv": "^8.18.0",
 		"basic-ftp": "^5.3.1"
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,13 @@
 		"webpack-dev-server": "^5.2.1",
 		"simple-git": "^3.32.3",
 		"minimatch@<3.1.3": "^3.1.3",
-		"js-yaml@<3.14.2": "^3.14.2"
+		"js-yaml@<3.14.2": "^3.14.2",
+		"axios": "^1.15.2",
+		"@babel/plugin-transform-modules-systemjs": "^7.29.4",
+		"fast-xml-builder": "^1.1.7",
+		"ip-address": "^10.1.1",
+		"ajv": "^8.18.0",
+		"basic-ftp": "^5.3.1"
 	},
 	"scripts": {
 		"wp-env": "wp-env",


### PR DESCRIPTION
## Summary

Adds `overrides` entries to `package.json` to pull patched versions of dev-only transitive dependencies flagged by [Dependabot](https://github.com/obenland/wp-last-login/security/dependabot). All affected packages come in via `@wordpress/scripts` / `@wordpress/env`; the published plugin is unaffected.

### Open alerts resolved

| Alert | Package | Patched to |
| --- | --- | --- |
| [#12](https://github.com/obenland/wp-last-login/security/dependabot/12), [#14](https://github.com/obenland/wp-last-login/security/dependabot/14), [#15](https://github.com/obenland/wp-last-login/security/dependabot/15), [#16](https://github.com/obenland/wp-last-login/security/dependabot/16), [#17](https://github.com/obenland/wp-last-login/security/dependabot/17), [#18](https://github.com/obenland/wp-last-login/security/dependabot/18), [#24](https://github.com/obenland/wp-last-login/security/dependabot/24), [#25](https://github.com/obenland/wp-last-login/security/dependabot/25), [#26](https://github.com/obenland/wp-last-login/security/dependabot/26), [#27](https://github.com/obenland/wp-last-login/security/dependabot/27) | `axios` | `^1.15.2` (resolves to 1.16.0) |
| [#23](https://github.com/obenland/wp-last-login/security/dependabot/23) | `@babel/plugin-transform-modules-systemjs` | `^7.29.4` |
| [#21](https://github.com/obenland/wp-last-login/security/dependabot/21), [#22](https://github.com/obenland/wp-last-login/security/dependabot/22) | `fast-xml-builder` | `^1.1.7` (resolves to 1.2.0) |
| [#11](https://github.com/obenland/wp-last-login/security/dependabot/11) | `ip-address` | `^10.1.1` (resolves to 10.2.0) |

### Auto-dismissed alert also addressed

- [#20](https://github.com/obenland/wp-last-login/security/dependabot/20) `basic-ftp` → `^5.3.1`

### Not patched: ajv (alert #3, auto-dismissed)

Forcing `ajv` to `^8.18.0` breaks `npm-package-json-lint` — it bundles `ajv-errors@1.x`, which only speaks ajv 6.x's `_opts` API and crashes the `lint:pkg-json` CI step. Dependabot auto-dismissed [#3](https://github.com/obenland/wp-last-login/security/dependabot/3) (dev-only, transitive), so leaving it untouched is the pragmatic call.

## Test plan

- [x] `npm install` regenerates `package-lock.json` cleanly
- [x] `npx wp-scripts lint-pkg-json` passes
- [x] `npm ls axios @babel/plugin-transform-modules-systemjs fast-xml-builder ip-address basic-ftp` confirms patched versions
- [ ] CI (PHPCS + PHPUnit single-site/multisite + package.json standards + Playwright) passes