### PR TITLE
Convert readme.txt to README.md

### DIFF
--- a/.github/workflows/phpunit-coverage.yml
+++ b/.github/workflows/phpunit-coverage.yml
@@ -5,7 +5,7 @@ on:
         types: [opened, synchronize, reopened]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -5,7 +5,7 @@ on:
         branches: [trunk]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'
@@ -15,7 +15,7 @@ on:
         branches: [trunk]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,7 +5,7 @@ on:
         branches: [trunk]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'
@@ -15,7 +15,7 @@ on:
         branches: [trunk]
         paths-ignore:
             - '**/*.md'
-            - 'readme.txt'
+            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -31,7 +31,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  sparse-checkout: readme.txt
+                  sparse-checkout: README.md
                   sparse-checkout-cone-mode: false
 
             - name: Compare latest WordPress against readme
@@ -49,9 +49,9 @@ jobs:
                       echo "Failed to derive major.minor from '$latest'" >&2
                       exit 1
                   fi
-                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ -z "$current" ]; then
-                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
+                      echo "Could not find 'Tested up to:' header in README.md" >&2
                       exit 1
                   fi
                   sorted=$(printf '%s\n%s\n' "$current" "$short" | sort -V)
@@ -241,15 +241,15 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Update readme.txt
+            - name: Update README.md
               shell: bash
               env:
                   TARGET: ${{ needs.check.outputs.version }}
                   PREVIOUS: ${{ needs.check.outputs.previous }}
               run: |
                   set -euo pipefail
-                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" readme.txt
-                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" README.md
+                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ "$new" != "$TARGET" ]; then
                       echo "sed did not produce expected value (got '$new')" >&2
                       exit 1
@@ -266,7 +266,7 @@ jobs:
                   body: |
                       WordPress ${{ needs.check.outputs.full }} is the latest stable release.
 
-                      Bumps `Tested up to` in readme.txt from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
+                      Bumps `Tested up to` in README.md from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
                   branch: chore/tested-up-to-${{ needs.check.outputs.version }}
                   delete-branch: true
 
@@ -319,7 +319,7 @@ jobs:
                   set -euo pipefail
                   # peter-evans/create-pull-request leaves the working tree at the pre-PR
                   # state, and the merge happens on the remote. Pull the post-merge trunk
-                  # so the SVN sync below copies the actually-bumped readme.txt rather than
+                  # so the SVN sync below copies the actually-bumped README.md rather than
                   # the workspace's stale copy.
                   git fetch origin trunk
                   git reset --hard origin/trunk

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-=== WP Last Login ===
+# WP Last Login
 Contributors: obenland
 Tags: admin, user, login, last login, login date
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=K32M878XHREQC
@@ -11,7 +11,7 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Adds a sortable "Last Login" column to the Users screen — spot inactive accounts and see who's actually using your site.
 
-== Description ==
+## Description
 
 **WP Last Login** records when each user signs in and surfaces it as a sortable column on the Users screen — so you can see who's active, identify dormant accounts, and confirm that real people are coming back.
 
@@ -25,20 +25,20 @@ Adds a sortable "Last Login" column to the Users screen — spot inactive accoun
 * Filter hooks let you customize the date format or hide the column from non-admin roles.
 
 
-== Installation ==
+## Installation
 
 1. Download WP Last Login.
 2. Unzip the folder into the `/wp-content/plugins/` directory.
 3. Activate the plugin through the 'Plugins' menu in WordPress.
 
 
-== Frequently Asked Questions ==
+## Frequently Asked Questions
 
-= Why does the column show an em-dash (—) for all my users? =
+### Why does the column show an em-dash (—) for all my users?
 
 The plugin records a login when a user signs in *after* it's been activated. WordPress doesn't store historical login data, so existing accounts will start populating their "Last Login" the next time each user logs in. Hovering the dash shows a tooltip explaining the same.
 
-= How do I change the date format or show the time? =
+### How do I change the date format or show the time?
 
 The date follows your site's general date format (Settings → General); the exact time appears on hover. To override the date format, use the `wpll_date_format` filter:
 
@@ -46,7 +46,7 @@ The date follows your site's general date format (Settings → General); the exa
         return 'Y-m-d H:i';
     } );
 
-= How do I hide the column from non-admin users? =
+### How do I hide the column from non-admin users?
 
 Filter `wpll_current_user_can` and return a capability check. Login tracking still happens — only column visibility is gated:
 
@@ -54,80 +54,80 @@ Filter `wpll_current_user_can` and return a capability check. Login tracking sti
         return current_user_can( 'manage_options' );
     } );
 
-= Does it work with multisite, Two Factor, WooCommerce, BuddyBoss, or social login plugins? =
+### Does it work with multisite, Two Factor, WooCommerce, BuddyBoss, or social login plugins?
 
 Yes. The plugin hooks into WordPress's standard `wp_login` action, so any login method that triggers it is captured. The Two Factor plugin (which interrupts `wp_login`) is supported via a dedicated hook.
 
-= What happens to my data if I deactivate the plugin? =
+### What happens to my data if I deactivate the plugin?
 
 Deactivating leaves stored login timestamps intact, so reactivating preserves history. Uninstalling (deleting the plugin entirely) removes all of the plugin's user meta.
 
 
-== Screenshots ==
+## Screenshots
 
 1. Last login column in the user table.
 
 
-== Changelog ==
+## Changelog
 
-= 7 =
+### 7
 * Added compatibility with Two Factor plugin. Props @bkno.
 * Improved date display to display login time on hover.
 
-= 6 =
+### 6
 * Revamped file structure to remove unnecessary files.
 * Fixed a bug where login dates were overwritten on plugin reactivation. Props @richardbuff.
 
-= 5 =
+### 5
 * Improved uninstall routine (no longer queries all users).
 * Updated utility class.
 * Tested with WordPress 6.1.
 
-= 4 =
+### 4
 * Improved date display to account for the timezone of the site. Props @knutsp.
 
-= 3 =
+### 3
 * Fixed a bug where users who haven't logged in disappear from user lists when ordering by last login. See https://wordpress.org/support/topic/new-users-dont-get-the-meta-field/
 
-= 2 =
+### 2
 * Maintenance release.
 * Updated code to adhere to WordPress Coding Standards.
 * Tested with WordPress 5.0.
 
-= 1.4.0 =
+### 1.4.0
 * Fixed a long standing bug, where sorting users by last login didn't work.
 * Tested with WordPress 4.3.
 
-= 1.3.0 =
+### 1.3.0
 * Maintenance release.
 * Tested with WordPress 4.0.
 
-= 1.2.1 =
+### 1.2.1
 * Reverts changes to wp_login() as the second argument seems not to be set at all times.
 
-= 1.2.0 =
+### 1.2.0
 * Users are now sortable by last login!
 * Updated utility class.
 * Added Danish translation. Props thomasclausen.
 
-= 1.1.2 =
+### 1.1.2
 * Fixed a bug where content of other custom columns were not displayed.
 
-= 1.1.1 =
+### 1.1.1
 * Updated utility class.
 
-= 1.1.0 =
+### 1.1.0
 * Made the display of the column filterable.
 * Widened the column a bit to accommodate for large date strings.
 
-= 1.0 =
+### 1.0
 * Initial Release.
 
 
-== Upgrade Notice ==
+## Upgrade Notice
 
 
-== Plugin Filter Hooks ==
+## Plugin Filter Hooks
 
 **wpll_current_user_can** (*boolean*)
 > Whether the column is supposed to be shown.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # WP Last Login
+
 Contributors: obenland
 Tags: admin, user, login, last login, login date
-Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=K32M878XHREQC
+Donate link: <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=K32M878XHREQC>
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 7
 License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
+License URI: <https://www.gnu.org/licenses/gpl-2.0.html>
 
 Adds a sortable "Last Login" column to the Users screen — spot inactive accounts and see who's actually using your site.
 
@@ -15,7 +16,7 @@ Adds a sortable "Last Login" column to the Users screen — spot inactive accoun
 
 **WP Last Login** records when each user signs in and surfaces it as a sortable column on the Users screen — so you can see who's active, identify dormant accounts, and confirm that real people are coming back.
 
-**Features**
+### Features
 
 * Sortable "Last Login" column on the Users screen, including the network admin user list on multisite.
 * Hover any date to reveal the exact login time.
@@ -71,56 +72,70 @@ Deactivating leaves stored login timestamps intact, so reactivating preserves hi
 ## Changelog
 
 ### 7
+
 * Added compatibility with Two Factor plugin. Props @bkno.
 * Improved date display to display login time on hover.
 
 ### 6
+
 * Revamped file structure to remove unnecessary files.
 * Fixed a bug where login dates were overwritten on plugin reactivation. Props @richardbuff.
 
 ### 5
+
 * Improved uninstall routine (no longer queries all users).
 * Updated utility class.
 * Tested with WordPress 6.1.
 
 ### 4
+
 * Improved date display to account for the timezone of the site. Props @knutsp.
 
 ### 3
-* Fixed a bug where users who haven't logged in disappear from user lists when ordering by last login. See https://wordpress.org/support/topic/new-users-dont-get-the-meta-field/
+
+* Fixed a bug where users who haven't logged in disappear from user lists when ordering by last login. See <https://wordpress.org/support/topic/new-users-dont-get-the-meta-field/>
 
 ### 2
+
 * Maintenance release.
 * Updated code to adhere to WordPress Coding Standards.
 * Tested with WordPress 5.0.
 
 ### 1.4.0
+
 * Fixed a long standing bug, where sorting users by last login didn't work.
 * Tested with WordPress 4.3.
 
 ### 1.3.0
+
 * Maintenance release.
 * Tested with WordPress 4.0.
 
 ### 1.2.1
+
 * Reverts changes to wp_login() as the second argument seems not to be set at all times.
 
 ### 1.2.0
+
 * Users are now sortable by last login!
 * Updated utility class.
 * Added Danish translation. Props thomasclausen.
 
 ### 1.1.2
+
 * Fixed a bug where content of other custom columns were not displayed.
 
 ### 1.1.1
+
 * Updated utility class.
 
 ### 1.1.0
+
 * Made the display of the column filterable.
 * Widened the column a bit to accommodate for large date strings.
 
 ### 1.0
+
 * Initial Release.
 
 


### PR DESCRIPTION
## Summary

Renames `readme.txt` to `README.md` (GitHub renders it on the repo home) without giving up the wp.org plugin page.

WordPress.org's plugin-directory parser accepts either filename — its lookup regex is `!(?:^|/)readme\.(txt|md)$!i` (case-insensitive, .md included) — and the section grammar already supports `##` headers alongside `==`. The WP field block (`Contributors:`, `Tested up to:`, `Stable tag:`, …) stays in the same `Field: Value` format in both files. Within sections, `### x.y.z` becomes the changelog entry form (since `###` doesn't end a section).

Workflows that read or write the readme are updated to point at `README.md`:

- `update-tested-up-to.yml` — sparse-checkout, the `[Tt]ested up to:` sed/grep, and the PR body
- `push-asset-readme-update.yml` / `plugin-asset-update.yml` — path triggers
- `phpunit*.yml`, `playwright*.yml`, `test-e2e.yml` — `paths-ignore` arrays

For uploads-unleashed, `release.yml`'s changelog-insertion logic is also rewritten: it now greps for `^### <tag>$` and inserts after `^## Changelog`, and `.distignore` no longer excludes `README.md` from the SVN sync.

## Test plan

- [ ] GitHub renders README.md on the repo home.
- [ ] Next scheduled `update-tested-up-to` run finds the `Tested up to:` header in README.md and behaves the same as before.
- [ ] wp.org plugin page continues to show the readme content on the next deploy (parser picks up README.md via the case-insensitive lookup).
