### PR TITLE
Pass README_NAME to the asset/readme workflow

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -14,4 +14,5 @@ jobs:
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  README_NAME: README.md
                   IGNORE_OTHER_FILES: true

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -330,4 +330,5 @@ jobs:
               env:
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  README_NAME: README.md
                   IGNORE_OTHER_FILES: true


### PR DESCRIPTION
## Summary

After the recent `readme.txt` → `README.md` rename, the asset/readme sync workflow has been failing on every trunk push:

```
cp: cannot stat '/home/runner/work/<plugin>/<plugin>/readme.txt': No such file or directory
```

The 10up plugin-asset-update action hardcodes `cp readme.txt …` in its "Copying files" step. Setting `README_NAME: README.md` in the env block tells the action which file to use.

## Test plan

- [ ] Next merge to trunk that touches README.md should sync cleanly to wp.org SVN trunk.
- [ ] SVN trunk should pick up the README.md alongside / replacing readme.txt (a one-time `svn rm readme.txt` is being done out-of-band).
