### PR TITLE
Run CI on README-only PRs so required checks report

### DIFF
--- a/.github/workflows/phpunit-coverage.yml
+++ b/.github/workflows/phpunit-coverage.yml
@@ -4,8 +4,6 @@ on:
     pull_request:
         types: [opened, synchronize, reopened]
         paths-ignore:
-            - '**/*.md'
-            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,8 +4,6 @@ on:
     push:
         branches: [trunk]
         paths-ignore:
-            - '**/*.md'
-            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'
@@ -14,8 +12,6 @@ on:
     pull_request:
         branches: [trunk]
         paths-ignore:
-            - '**/*.md'
-            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,8 +4,6 @@ on:
     push:
         branches: [trunk]
         paths-ignore:
-            - '**/*.md'
-            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'
@@ -14,8 +12,6 @@ on:
     pull_request:
         branches: [trunk]
         paths-ignore:
-            - '**/*.md'
-            - 'README.md'
             - 'lang/**'
             - '.wordpress-org/**'
             - '.distignore'


### PR DESCRIPTION
## Summary

- The Tested-up-to bot (`update-tested-up-to.yml`) opens PRs that touch only `README.md`. Because PHPUnit, PHPUnit Coverage, and Playwright all listed `**/*.md` / `README.md` under `paths-ignore`, none of them ran on those PRs.
- Required status checks on `trunk` then never reported, leaving `mergeStateStatus: BLOCKED` indefinitely — `gh pr merge --auto` queued the merge but it never fired. That's why [run 26188917047](https://github.com/obenland/wp-last-login/actions/runs/26188917047) failed at the "Merge PR" step on PR #44.
- Dropping just the markdown entries makes the required checks run on README-only PRs so auto-merge can proceed. `lang/**`, `.wordpress-org/**`, and the dotfile excludes stay — they aren't gated by required checks.

## Test plan

- [ ] Required checks run on this PR (they will, since it changes `.github/workflows/*.yml`)
- [ ] After this lands, push an empty commit to PR #44 (or close+reopen) to re-trigger workflows; verify the required checks now run and auto-merge fires
- [ ] Next scheduled Tested-up-to run merges cleanly without operator intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)