### PR TITLE
Fix tmp path traversal (GHSA-ph9p-34f9-6g65)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24648,9 +24648,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tmp": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {


### PR DESCRIPTION
Bumps the transitive dev dependency `tmp` from a vulnerable version (< 0.2.6) to 0.2.7, resolving Dependabot alert GHSA-ph9p-34f9-6g65 (arbitrary file/directory write via path traversal).

Lockfile-only change; no production code or runtime dependencies affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)